### PR TITLE
Extract the colour definitions into their own Sass file

### DIFF
--- a/colors.scss
+++ b/colors.scss
@@ -1,0 +1,36 @@
+/**
+ * Dark Mode Colours
+ */
+
+/** 
+ * The colours below are loosely based on the WordPress branding colours.
+ * https://make.wordpress.org/design/handbook/design-guide/foundations/colors/
+ */
+$white:           #ffffff;
+$black:           #000000;
+$blue:            #0073aa;
+$medium-blue:     #00a0d2;
+$clear:           transparent;
+
+$accent-red:      #dc3232;
+$accent-orange:   #f56e28;
+$accent-yellow:   #ffb900;
+$accent-green:    #46b450;
+$accent-blue:     $blue;
+$accent-purple:   #826eb4;
+
+$base-grey:       #23282d;
+$light-grey:      #bbc8d4;
+$heavy-grey:      #37444c;
+$dark-grey:       #32373c;
+$ultra-grey:      #191f25;
+$dark-silver:     #50626f;
+$base-blue:       #2e74aa;
+$light-blue:      #4092d2;
+$dark-blue:       #2c5f88;
+$ultra-blue:      #1f3f58;
+$bright-blue:     #30ceff;
+
+$editor-lavender: #c678dd;
+$editor-sunglo:   #e06c75;
+$editor-olivine:  #98c379;

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -2,38 +2,7 @@
  * Dark Mode CSS
  */
 
-/** 
- * The colours below are loosely based on the WordPress branding colours.
- * https://make.wordpress.org/design/handbook/design-guide/foundations/colors/
- */
-$white:           #ffffff;
-$black:           #000000;
-$blue:            #0073aa;
-$medium-blue:     #00a0d2;
-$clear:           transparent;
-
-$accent-red:      #dc3232;
-$accent-orange:   #f56e28;
-$accent-yellow:   #ffb900;
-$accent-green:    #46b450;
-$accent-blue:     $blue;
-$accent-purple:   #826eb4;
-
-$base-grey:       #23282d;
-$light-grey:      #bbc8d4;
-$heavy-grey:      #37444c;
-$dark-grey:       #32373c;
-$ultra-grey:      #191f25;
-$dark-silver:     #50626f;
-$base-blue:       #2e74aa;
-$light-blue:      #4092d2;
-$dark-blue:       #2c5f88;
-$ultra-blue:      #1f3f58;
-$bright-blue:     #30ceff;
-
-$editor-lavender: #c678dd;
-$editor-sunglo:   #e06c75;
-$editor-olivine:  #98c379;
+@import "colors";
 
 body:not(.gutenberg-editor-page) {
 


### PR DESCRIPTION
As part of the build process of a plugin of mine, I want to produce a Dark Mode compatible colour scheme which directly uses the Sass variables from this plugin as a basis.

In order to do that without also importing all the CSS declarations, the variable definitions need to be in their own file which I can then import separately.