### PR TITLE
Enhance postbox tables

### DIFF
--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -615,6 +615,7 @@ body:not(.gutenberg-editor-page) {
 			td {
 
 				background-color: $clear;
+				border-color: $ultra-grey;
 
 			}
 

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -602,7 +602,9 @@ body:not(.gutenberg-editor-page) {
 
 		}
 
-		.card {
+		.card,
+		.postbox,
+		.stuffbox {
 
 			table,
 			thead,


### PR DESCRIPTION
Tables within postbox and stuffbox are currently too dark. WP styles don't have different colors for tables within these boxes. This PR fixes that.
This PR also changes the table/tr/td border colors to dark.