### PR TITLE
Various enhancements - Initial: Use darker BG to create contrast with the admin menu

### DIFF
--- a/class-dark-mode.php
+++ b/class-dark-mode.php
@@ -13,7 +13,7 @@ class Dark_Mode {
 	 *
 	 * @since 3.0
 	 */
-	const PLUGIN_VERSION = '3.1';
+	const PLUGIN_VERSION = '3.2';
 
 	/**
 	 * Make WordPress Dark.

--- a/dark-mode-colors.scss
+++ b/dark-mode-colors.scss
@@ -18,7 +18,7 @@ $accent-blue:     $blue;
 $accent-purple:   #826eb4;
 
 $base-grey:       #23282d;
-$light-grey:      #bbc8d4;
+$light-grey:      #d0d4d8;
 $heavy-grey:      #37444c;
 $dark-grey:       #32373c;
 $deep-grey:       #202529;

--- a/dark-mode-colors.scss
+++ b/dark-mode-colors.scss
@@ -17,7 +17,7 @@ $accent-green:    #46b450;
 $accent-blue:     $blue;
 $accent-purple:   #826eb4;
 
-$base-grey:       #1f2123;
+$base-grey:       #23282d;
 $light-grey:      #bbc8d4;
 $heavy-grey:      #37444c;
 $dark-grey:       #32373c;

--- a/dark-mode-colors.scss
+++ b/dark-mode-colors.scss
@@ -17,7 +17,7 @@ $accent-green:    #46b450;
 $accent-blue:     $blue;
 $accent-purple:   #826eb4;
 
-$base-grey:       #23282d;
+$base-grey:       #1f2123;
 $light-grey:      #bbc8d4;
 $heavy-grey:      #37444c;
 $dark-grey:       #32373c;

--- a/dark-mode-colors.scss
+++ b/dark-mode-colors.scss
@@ -3,12 +3,14 @@
  *
  * The colours below are loosely based on the WordPress branding colours.
  * https://make.wordpress.org/design/handbook/design-guide/foundations/colors/
+ * https://codepen.io/hugobaeta/pen/RNOzoV
  */
 $white:           #ffffff;
 $black:           #000000;
-$blue:            #0073aa;
-$medium-blue:     #00a0d2;
 $clear:           transparent;
+
+$blue:            #0073aa; // WordPress blue
+$medium-blue:     #00a0d2; // Medium blue
 
 $accent-red:      #dc3232;
 $accent-orange:   #f56e28;
@@ -17,20 +19,20 @@ $accent-green:    #46b450;
 $accent-blue:     $blue;
 $accent-purple:   #826eb4;
 
-$base-grey:       #23282d;
-$light-grey:      #d0d4d8;
-$heavy-grey:      #37444c;
-$dark-grey:       #32373c;
+$ultra-grey:      #191f25; // Dark grey 900
 $deep-grey:       #202529;
-$ultra-grey:      #191f25;
+$base-grey:       #23282d; // Dark grey 800
+$dark-grey:       #32373c; // Dark grey 700
+$heavy-grey:      #37444c;
+$light-grey:      #ccd0d4; // Light Grey 700
 
-$light-silver:    #bbc8d4;
 $dark-silver:     #50626f;
+$light-silver:    #bbc8d4;
 
+$ultra-blue:      #1f3f58;
+$dark-blue:       #2c5f88;
 $base-blue:       #2e74aa;
 $light-blue:      #4092d2;
-$dark-blue:       #2c5f88;
-$ultra-blue:      #1f3f58;
 $bright-blue:     #30ceff;
 
 $editor-lavender: #c678dd;

--- a/dark-mode-colors.scss
+++ b/dark-mode-colors.scss
@@ -23,7 +23,10 @@ $heavy-grey:      #37444c;
 $dark-grey:       #32373c;
 $deep-grey:       #202529;
 $ultra-grey:      #191f25;
+
+$light-silver:    #bbc8d4;
 $dark-silver:     #50626f;
+
 $base-blue:       #2e74aa;
 $light-blue:      #4092d2;
 $dark-blue:       #2c5f88;

--- a/dark-mode-colors.scss
+++ b/dark-mode-colors.scss
@@ -29,6 +29,8 @@ $dark-blue:       #2c5f88;
 $ultra-blue:      #1f3f58;
 $bright-blue:     #30ceff;
 
+$striped-grey:    #202529;
+
 $editor-lavender: #c678dd;
 $editor-sunglo:   #e06c75;
 $editor-olivine:  #98c379;

--- a/dark-mode-colors.scss
+++ b/dark-mode-colors.scss
@@ -21,6 +21,7 @@ $base-grey:       #23282d;
 $light-grey:      #bbc8d4;
 $heavy-grey:      #37444c;
 $dark-grey:       #32373c;
+$deep-grey:       #202529;
 $ultra-grey:      #191f25;
 $dark-silver:     #50626f;
 $base-blue:       #2e74aa;
@@ -28,8 +29,6 @@ $light-blue:      #4092d2;
 $dark-blue:       #2c5f88;
 $ultra-blue:      #1f3f58;
 $bright-blue:     #30ceff;
-
-$striped-grey:    #202529;
 
 $editor-lavender: #c678dd;
 $editor-sunglo:   #e06c75;

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -1996,13 +1996,25 @@ body:not(.gutenberg-editor-page) {
 
 		}
 
+		&-menubar,
 		&-panel {
 
-			background: $dark-grey;
+			background-color: $dark-grey;
 
 			&.mce-menu {
 
 				border-color: $ultra-grey;
+
+			}
+
+			.mce-menubtn button {
+
+				&,
+				& span {
+
+					color: $light-grey;
+
+				}
 
 			}
 
@@ -2031,7 +2043,44 @@ body:not(.gutenberg-editor-page) {
 
 				}
 
+				&.mce-disabled {
+
+					background-color: $clear;
+					color: $dark-silver;
+
+					.mce-ico,
+					.mce-text {
+
+						color: $dark-silver;
+
+					}
+
+					&.mce-active,
+					&.mce-selected,
+					&:focus,
+					&:hover {
+
+						background-color: $ultra-grey;
+
+						.mce-ico,
+						.mce-text {
+
+							color: $dark-silver;
+
+						}
+
+					}
+
+				}
+
 			}
+
+		}
+
+		&-menubar {
+
+			background-color: $base-grey;
+			border-color: $clear;
 
 		}
 

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -159,7 +159,7 @@ body:not(.gutenberg-editor-page) {
 					td,
 					th {
 
-						border-color: $heavy-grey;
+						border-color: $ultra-grey;
 
 					}
 

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -102,7 +102,7 @@ body:not(.gutenberg-editor-page) {
 
 						&:nth-child(odd) {
 
-							background-color: $striped-grey;
+							background-color: $deep-grey;
 
 						}
 

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -54,7 +54,7 @@ body:not(.gutenberg-editor-page) {
 
 			tr {
 
-				background-color: $base-grey;
+				background-color: $clear;
 
 				th,
 				td {

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -677,7 +677,9 @@ body:not(.gutenberg-editor-page) {
 		.filter-drawer,
 		.wp-filter .favorites-form,
 		.filter-group,
-		.filtered-by .tag {
+		.filtered-by .tag,
+		ul.cat-checklist,
+		#bulk-titles {
 
 			background-color: $dark-grey;
 			border-color: $ultra-grey;

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -712,11 +712,16 @@ body:not(.gutenberg-editor-page) {
 
 		.plugin-card,
 		.plugin-card-bottom,
-		#nav-menu-header,
 		#menu-management .menu-edit,
 		.wp-editor-container {
 
 			border-color: $ultra-grey;
+
+		}
+
+		#nav-menu-header {
+
+			border-color: $clear;
 
 		}
 
@@ -765,8 +770,8 @@ body:not(.gutenberg-editor-page) {
 		&.js .control-section.open .accordion-section-title,
 		&.js .control-section:hover .accordion-section-title {
 
-			background-color: $ultra-grey;
-			border-color: $base-grey;
+			background-color: $base-grey;
+			border-color: $ultra-grey;
 			color: $light-grey;
 
 		}
@@ -811,7 +816,7 @@ body:not(.gutenberg-editor-page) {
 		.stuffbox .hndle,
 		.widgets-chooser ul {
 
-			border-color: $base-grey;
+			border-color: $dark-grey;
 
 		}
 
@@ -847,11 +852,18 @@ body:not(.gutenberg-editor-page) {
 
 		}
 
-		.menu-item-handle,
-		.manage-menus,
 		#menu-management {
 
 			background: $ultra-grey;
+			border-color: $dark-grey;
+
+		}
+
+		.menu-item-handle,
+		.manage-menus,
+		#menu-management .menu-edit {
+
+			background-color: $base-grey;
 			border-color: $dark-grey;
 
 		}
@@ -865,10 +877,11 @@ body:not(.gutenberg-editor-page) {
 
 		.menu-item-bar .menu-item-handle {
 
-			&,
+			border-color: $ultra-grey;
+
 			&:hover {
 
-				border-color: $base-grey;
+				border-color: $dark-silver;
 
 			}
 
@@ -1285,7 +1298,7 @@ body:not(.gutenberg-editor-page) {
 		#customize-outer-theme-controls .customize-info .customize-section-description {
 
 			background-color: $base-grey;
-			border-color: $ultra-grey;
+			border-color: $dark-grey;
 			color: $light-grey;
 
 		}

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -1580,11 +1580,11 @@ body:not(.gutenberg-editor-page) {
 			background: $ultra-grey;
 			border-color: $white;
 			border-left-color: $ultra-grey;
-			
+
 			.setting span {
 
 				color: $light-grey;
-				
+
 			}
 
 			h2 {
@@ -1769,7 +1769,7 @@ body:not(.gutenberg-editor-page) {
 		}
 
 		.wp-core-ui {
-			
+
 			.attachment-preview {
 
 				background: $heavy-grey;
@@ -1789,7 +1789,7 @@ body:not(.gutenberg-editor-page) {
 				box-shadow: inset 0 0 2px 3px $dark-silver, inset 0 0 0 7px $light-blue;
 
 			}
-			
+
 		}
 
 		.embed-url {
@@ -2371,20 +2371,20 @@ body:not(.gutenberg-editor-page) {
 
 		&.readonly,
 		&.disabled {
-		
+
 			background-color: $dark-grey;
 			color: $light-grey;
 			opacity: 0.75;
-		
+
 		}
 
 		&[readonly],
 		&[disabled] {
-		
+
 			background-color: $dark-grey;
 			color: $light-grey;
 			opacity: 0.75;
-		
+
 		}
 
 	}

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -623,8 +623,8 @@ body:not(.gutenberg-editor-page) {
 		.wp-filter,
 		.menu-edit #post-body {
 
-			background-color: $dark-grey;
-			border-color: $ultra-grey;
+			background-color: $base-grey;
+			border-color: $dark-grey;
 			color: $light-grey;
 
 			p,

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -450,7 +450,7 @@ body:not(.gutenberg-editor-page) {
 
 		.widgets-holder-wrap {
 
-			background-color: $base-grey;
+			background-color: $clear;
 			border-color: $clear;
 
 			.sidebar-name {
@@ -473,7 +473,7 @@ body:not(.gutenberg-editor-page) {
 
 			.widgets-sortables {
 
-				background-color: $base-grey;
+				background-color: $clear;
 
 			}
 
@@ -488,7 +488,7 @@ body:not(.gutenberg-editor-page) {
 
 					&:hover {
 
-						border-color: $dark-grey;
+						border-color: $dark-silver;
 
 					}
 
@@ -534,7 +534,35 @@ body:not(.gutenberg-editor-page) {
 
 						}
 
+						.widgets-chooser-button {
+
+							color: $white;
+
+						}
+
 					}
+
+				}
+
+			}
+
+		}
+
+		#widgets-right {
+
+			.widgets-holder-wrap {
+
+				background-color: $dark-grey;
+
+				.widgets-sortables {
+
+					background-color: $dark-grey;
+
+				}
+
+				.widget-top {
+
+					border-color: $ultra-grey;
 
 				}
 
@@ -775,7 +803,6 @@ body:not(.gutenberg-editor-page) {
 		.menu-item-handle,
 		.popular-tags,
 		.stuffbox,
-		.widget-inside,
 		.widget-top,
 		p.popular-tags,
 		.postbox .hndle,
@@ -811,14 +838,26 @@ body:not(.gutenberg-editor-page) {
 
 		}
 
+		.widget-inside {
+
+			background: $dark-grey;
+			border-color: $ultra-grey;
+
+		}
+
 		.menu-item-handle,
-		.widget .widget-top,
-		.widget-inside,
 		.manage-menus,
 		#menu-management {
 
 			background: $ultra-grey;
 			border-color: $dark-grey;
+
+		}
+
+		.widget .widget-top {
+
+			background-color: $base-grey;
+			border-color: $heavy-grey;
 
 		}
 

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -6,13 +6,13 @@
 
 body:not(.gutenberg-editor-page) {
 
-	background-color: $base-grey;
+	background-color: $ultra-grey;
 	color: $light-grey;
 
 	#wpbody,
 	#wpfooter {
 
-		background-color: $base-grey;
+		background-color: $ultra-grey;
 		color: $light-grey;
 
 		p,

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -98,11 +98,11 @@ body:not(.gutenberg-editor-page) {
 
 					tr {
 
-						background-color: $dark-grey;
+						background-color: $base-grey;
 
 						&:nth-child(odd) {
 
-							background-color: $base-grey;
+							background-color: $striped-grey;
 
 						}
 

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -806,7 +806,7 @@ body:not(.gutenberg-editor-page) {
 		.wp-editor-expand #wp-content-editor-tools,
 		#wp-content-editor-tools {
 
-			background-color: $clear;
+			background-color: $ultra-grey;
 			border-color: $dark-grey;
 
 		}

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -432,12 +432,18 @@ body:not(.gutenberg-editor-page) {
 
 		}
 
+		#contextual-help-back {
+
+			background-color: $heavy-grey;
+			border-color: $ultra-grey;
+
+		}
+
 		#wpwrap,
-		#contextual-help-back,
 		#plugin-information-content,
 		.notification-dialog {
 
-			background-color: $base-grey;
+			background-color: $dark-grey;
 			border-color: $ultra-grey;
 
 		}
@@ -540,7 +546,7 @@ body:not(.gutenberg-editor-page) {
 
 			.active a {
 
-				background-color: $base-grey;
+				background-color: $heavy-grey;
 				border-color: $dark-grey;
 				color: $light-grey;
 

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -930,7 +930,6 @@ body:not(.gutenberg-editor-page) {
 
 		}
 
-		.media-frame-content,
 		.edit-attachment-frame .attachment-info {
 
 			background-color: $base-grey;

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -648,6 +648,12 @@ body:not(.gutenberg-editor-page) {
 
 		}
 
+		.menu-edit #post-body {
+
+			background-color: $dark-grey;
+
+		}
+
 		.card {
 
 			table,

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -910,7 +910,7 @@ body:not(.gutenberg-editor-page) {
 		.wrap h2.nav-tab-wrapper,
 		h1.nav-tab-wrapper {
 
-			border-color: $light-grey;
+			border-color: $dark-silver;
 
 		}
 
@@ -923,7 +923,7 @@ body:not(.gutenberg-editor-page) {
 			&:focus,
 			&:hover {
 
-				background-color: $ultra-grey;
+				background-color: $black;
 
 			}
 
@@ -936,9 +936,10 @@ body:not(.gutenberg-editor-page) {
 		.about-wrap h2 .nav-tab-active,
 		.media-modal-content {
 
-			background-color: $light-grey;
-			border-color: $light-grey;
-			color: $ultra-grey;
+			background-color: $ultra-grey;
+			border-color: $dark-silver;
+			border-bottom-color: $ultra-grey;
+			color: $light-grey;
 
 		}
 

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -806,7 +806,7 @@ body:not(.gutenberg-editor-page) {
 		.wp-editor-expand #wp-content-editor-tools,
 		#wp-content-editor-tools {
 
-			background-color: $base-grey;
+			background-color: $clear;
 			border-color: $dark-grey;
 
 		}

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -153,6 +153,18 @@ body:not(.gutenberg-editor-page) {
 
 				}
 
+				thead tr,
+				tfoot tr {
+
+					td,
+					th {
+
+						border-color: $heavy-grey;
+
+					}
+
+				}
+
 			}
 
 			&.updates-table {

--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -253,7 +253,7 @@ body:not(.gutenberg-editor-page) {
 		.updated,
 		.update-nag {
 
-			background-color: $ultra-grey;
+			background-color: $dark-grey;
 
 		}
 


### PR DESCRIPTION
In default WP the admin menu has a different color than the "content". Even with the light theme there is a bit of contrast there.
IMO it's better to keep this bit of contrast in dark mode as well. This change makes the background a bit darker to create this slight contrast with the default color scheme. It also changes the other elements based upon this darker background color.

## Screenshots:

_EDIT: Sorry for the Keraweb logo. Forgot that one. I'm using the default admin theme in these examples._

### Dashboard:
![image](https://user-images.githubusercontent.com/826148/50190970-c8de4e00-032b-11e9-929c-fa0d5bff6e8f.png)

### Pages
![image](https://user-images.githubusercontent.com/826148/50191015-ff1bcd80-032b-11e9-948e-14a1d0e0ef21.png)

### Menus
![image](https://user-images.githubusercontent.com/826148/50190990-de537800-032b-11e9-8e1f-ce5e08ba29e7.png)

### Widgets
![image](https://user-images.githubusercontent.com/826148/50190994-e3b0c280-032b-11e9-94f3-36181c549bc3.png)
