### PR TITLE
Add network-active label color in plugins list

### DIFF
--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -121,6 +121,12 @@ body:not(.gutenberg-editor-page) {
 
 				}
 
+				.network_active {
+
+					color: $light-grey;
+
+				}
+
 				tr.active+tr.inactive td,
 				tr.active+tr.inactive th,
 				tr.active.plugin-update-tr+tr.inactive td,


### PR DESCRIPTION
This is specifically made black in WP default so this plugin should overwrite that.