### PR TITLE
Widgets screen containers

### DIFF
--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -473,6 +473,22 @@ body:not(.gutenberg-editor-page) {
 
 		}
 
+		#widgets-right {
+
+			.widgets-holder-wrap {
+
+				background-color: $dark-grey;
+
+				.widgets-sortables {
+
+					background-color: $dark-grey;
+
+				}
+
+			}
+
+		}
+
 		#widgets-left,
 		#widgets-right {
 


### PR DESCRIPTION
Widget containers have the same background as postboxes in WP default