### PR TITLE
Do not load dark mode for block editor

### DIFF
--- a/class-dark-mode.php
+++ b/class-dark-mode.php
@@ -103,35 +103,43 @@ class Dark_Mode {
 	 */
 	public static function load_dark_mode_css() {
 		// Has the user enabled Dark Mode?
-		if ( false !== self::is_using_dark_mode() ) {
-			$user_id = get_current_user_id();
-
-			/**
-			 * Fires just before the stylesheet is included.
-			 *
-			 * @since 1.0
-			 * @since 2.1 Added `$user_id` integer.
-			 *
-			 * @param int $user_id The current user id.
-			 */
-			do_action( 'doing_dark_mode', $user_id );
-
-			/**
-			 * Filters the Dark Mode stylesheet URL.
-			 *
-			 * @since 1.1
-			 * @since 2.1 Removed second parameter from `plugins_url()`.
-			 * @since 3.0 Changed CSS file to include hyphen in name.
-			 *
-			 * @param string $css_url Default CSS file path for Dark Mode.
-			 *
-			 * @return string $css_url
-			 */
-			$css_url = apply_filters( 'dark_mode_css', plugins_url( 'dark-mode' ) . '/dark-mode.css' );
-
-			// Enqueue the stylesheet.
-			wp_enqueue_style( 'dark_mode', $css_url, array(), self::PLUGIN_VERSION );
+		if ( ! self::is_using_dark_mode() ) {
+			return;
 		}
+
+		// @todo Disabled for now if the new block editor is active (since WP 5.0).
+		$screen = get_current_screen();
+		if ( method_exists( $screen, 'is_block_editor' ) && $screen->is_block_editor() ) {
+			return;
+		}
+
+		$user_id = get_current_user_id();
+
+		/**
+		 * Fires just before the stylesheet is included.
+		 *
+		 * @since 1.0
+		 * @since 2.1 Added `$user_id` integer.
+		 *
+		 * @param int $user_id The current user id.
+		 */
+		do_action( 'doing_dark_mode', $user_id );
+
+		/**
+		 * Filters the Dark Mode stylesheet URL.
+		 *
+		 * @since 1.1
+		 * @since 2.1 Removed second parameter from `plugins_url()`.
+		 * @since 3.0 Changed CSS file to include hyphen in name.
+		 *
+		 * @param string $css_url Default CSS file path for Dark Mode.
+		 *
+		 * @return string $css_url
+		 */
+		$css_url = apply_filters( 'dark_mode_css', plugins_url( 'dark-mode' ) . '/dark-mode.css' );
+
+		// Enqueue the stylesheet.
+		wp_enqueue_style( 'dark_mode', $css_url, array(), self::PLUGIN_VERSION );
 	}
 
 	/**


### PR DESCRIPTION
Currently this is temp fixed within the CSS but since 5.0 the current screen has a method `is_block_editor()` to use.
This adds this method to check for the block editor as long as this screen isn't available in dark mode yet.

Fixes #133

Todo: I think the temp fix within CSS can be removed. (`body:not(.gutenberg-editor-page)`)