### PR TITLE
Feature: Admin bar toggle

### DIFF
--- a/class-dark-mode.php
+++ b/class-dark-mode.php
@@ -35,6 +35,8 @@ class Dark_Mode {
 
 		add_filter( 'plugin_action_links', array( __CLASS__, 'add_plugin_links' ), 10, 2 );
 		add_filter( 'admin_body_class', array( __CLASS__, 'add_body_class' ), 10, 1 );
+
+		add_action( 'admin_bar_menu', array( __CLASS__, 'admin_bar_menu' ), 11 );
 	}
 
 	/**
@@ -218,6 +220,34 @@ class Dark_Mode {
 			 */
 			do_action( 'after_dark_mode_saved', $option, $user_id );
 		}
+	}
+
+	/**
+	 * Add the switcher toolbar node.
+	 *
+	 * @since X
+	 *
+	 * @param  \WP_Admin_Bar $admin_bar
+	 *
+	 * @return void
+	 */
+	public static function admin_bar_menu( $admin_bar ) {
+		if ( self::is_using_dark_mode() ) {
+			$title = __( 'Disable Dark Mode', 'dark-mode' );
+			$link  = add_query_arg( 'dark_mode', 0 );
+		} else {
+			$title = __( 'Enable Dark Mode', 'dark-mode' );
+			$link  = add_query_arg( 'dark_mode', 1 );
+		}
+
+		$link = add_query_arg( 'dark_mode_nonce', wp_create_nonce( 'dark_mode_nonce' ), $link );
+
+		$admin_bar->add_node( array(
+			'id'     => 'dark-mode',
+			'parent' => 'user-actions',
+			'title'  => $title,
+			'href'   => $link,
+		) );
 	}
 
 	/**

--- a/class-dark-mode.php
+++ b/class-dark-mode.php
@@ -23,6 +23,7 @@ class Dark_Mode {
 	 * @since 1.3 Added hook for the Feedback link in the toolbar.
 	 * @since 1.8 Added filter for the plugin table links and removed admin toolbar hook.
 	 * @since 3.1 Added the admin body class filter.
+	 * @since 3.2 Added the admin bar toggle node.
 	 *
 	 * @return void
 	 */

--- a/class-dark-mode.php
+++ b/class-dark-mode.php
@@ -170,7 +170,7 @@ class Dark_Mode {
 			<td>
 				<p>
 					<label for="dark_mode">
-						<input type="checkbox" id="dark_mode" name="dark_mode" class="dark_mode"
+						<input type="checkbox" id="dark_mode" name="dark_mode" class="dark_mode" value="1"
 						<?php checked( get_user_meta( $user->data->ID, 'dark_mode', true ), 'on', true ); ?> />
 						<?php esc_html_e( 'Enable Dark Mode in the dashboard', 'dark-mode' ); ?>
 					</label>
@@ -207,7 +207,7 @@ class Dark_Mode {
 	public static function save_profile_fields( $user_id ) {
 		if ( wp_verify_nonce( sanitize_key( $_POST['dark_mode_nonce'] ), 'dark_mode_nonce' ) ) {
 			// Set the option value.
-			$option = isset( $_POST['dark_mode'] ) ? 'on' : 'off';
+			$option = ! empty( $_POST['dark_mode'] ) ? 'on' : 'off';
 
 			/**
 			 * Filter the user's Dark Mode choice.

--- a/class-dark-mode.php
+++ b/class-dark-mode.php
@@ -27,7 +27,7 @@ class Dark_Mode {
 	 * @return void
 	 */
 	public function __construct() {
-		add_action( 'plugins_loaded', array( __CLASS__, 'load_text_domain' ), 10, 0 );
+		add_action( 'plugins_loaded', array( __CLASS__, 'plugins_loaded' ), 10, 0 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'load_dark_mode_css' ), 99, 0 );
 		add_action( 'personal_options', array( __CLASS__, 'add_profile_fields' ), 10, 1 );
 		add_action( 'personal_options_update', array( __CLASS__, 'save_profile_fields' ), 10, 1 );
@@ -40,13 +40,25 @@ class Dark_Mode {
 	}
 
 	/**
+	 * Run when all plugins are loaded.
 	 * Load the plugin text domain.
 	 *
 	 * @since 1.0
 	 *
 	 * @return void
 	 */
-	public static function load_text_domain() {
+	public static function plugins_loaded() {
+
+		// Admin bar toggle.
+		if ( ! empty( $_GET['dark_mode_nonce'] ) ) {
+			$_POST['dark_mode_nonce'] = $_GET['dark_mode_nonce'];
+			$_POST['dark_mode']       = $_GET['dark_mode'];
+
+			self::save_profile_fields( get_current_user_id() );
+
+			wp_safe_redirect( remove_query_arg( array( 'dark_mode', 'dark_mode_nonce' ) ) );
+		}
+
 		load_plugin_textdomain( 'dark-mode', false, untrailingslashit( dirname( __FILE__ ) ) . '/languages' );
 	}
 

--- a/class-dark-mode.php
+++ b/class-dark-mode.php
@@ -36,7 +36,9 @@ class Dark_Mode {
 		add_filter( 'plugin_action_links', array( __CLASS__, 'add_plugin_links' ), 10, 2 );
 		add_filter( 'admin_body_class', array( __CLASS__, 'add_body_class' ), 10, 1 );
 
-		add_action( 'admin_bar_menu', array( __CLASS__, 'admin_bar_menu' ), 11 );
+		if ( is_admin() ) {
+			add_action( 'admin_bar_menu', array( __CLASS__, 'admin_bar_menu' ), 11 );
+		}
 	}
 
 	/**

--- a/class-dark-mode.php
+++ b/class-dark-mode.php
@@ -46,6 +46,7 @@ class Dark_Mode {
 	 * Load the plugin text domain.
 	 *
 	 * @since 1.0
+	 * @since 3.2 Admin bar toggle.
 	 *
 	 * @return void
 	 */
@@ -239,9 +240,9 @@ class Dark_Mode {
 	/**
 	 * Add the switcher toolbar node.
 	 *
-	 * @since X
+	 * @since 3.2
 	 *
-	 * @param  \WP_Admin_Bar $admin_bar
+	 * @param \WP_Admin_Bar $admin_bar
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
I saw this request multiple times on wp.org support.
This PR adds an admin bar node on the "My Account" dropdown to toggle dark mode.