### PR TITLE
Remove filter `not_using_dark_mode` and cache results

### DIFF
--- a/class-dark-mode.php
+++ b/class-dark-mode.php
@@ -82,9 +82,10 @@ class Dark_Mode {
 		 * Filters when Dark Mode is on.
 		 *
 		 * @since 2.0
+		 * @since 3.2 Removed `not_using_dark_mode` filter and pass the enabled status through the first parameter.
 		 *
-		 * @param boolean          Defaults to true.
-		 * @param int     $user_id The current user id.
+		 * @param boolean $is_using_dark_mode Has the user enabled Dark Mode?
+		 * @param int     $user_id            The current user id.
 		 */
 		$cache[ $user_id ] = apply_filters( 'is_using_dark_mode', $is_using_dark_mode, $user_id );
 

--- a/class-dark-mode.php
+++ b/class-dark-mode.php
@@ -59,15 +59,21 @@ class Dark_Mode {
 	 * @since 1.0
 	 * @since 1.6 Major rewrite to properly address automatic Dark Mode.
 	 * @since 2.0 Removed the automatic checks and added filters.
-	 * @since 3.2 Removed `not_using_dark_mode` filter.
+	 * @since 3.2 Removed `not_using_dark_mode` filter and implemented static cache.
 	 *
 	 * @param int $user_id The user id to check.
 	 *
 	 * @return boolean
 	 */
 	public static function is_using_dark_mode( $user_id = 0 ) {
+		static $cache = array();
+
 		if ( 0 === $user_id ) {
 			$user_id = get_current_user_id();
+		}
+
+		if ( isset( $cache[ $user_id ] ) ) {
+			return $cache[ $user_id ];
 		}
 
 		$is_using_dark_mode = ( 'on' === get_user_meta( $user_id, 'dark_mode', true ) );
@@ -80,7 +86,9 @@ class Dark_Mode {
 		 * @param boolean          Defaults to true.
 		 * @param int     $user_id The current user id.
 		 */
-		return = apply_filters( 'is_using_dark_mode', $is_using_dark_mode, $user_id );
+		$cache[ $user_id ] = apply_filters( 'is_using_dark_mode', $is_using_dark_mode, $user_id );
+
+		return $cache[ $user_id ];
 	}
 
 	/**

--- a/class-dark-mode.php
+++ b/class-dark-mode.php
@@ -59,6 +59,7 @@ class Dark_Mode {
 	 * @since 1.0
 	 * @since 1.6 Major rewrite to properly address automatic Dark Mode.
 	 * @since 2.0 Removed the automatic checks and added filters.
+	 * @since 3.2 Removed `not_using_dark_mode` filter.
 	 *
 	 * @param int $user_id The user id to check.
 	 *
@@ -69,28 +70,17 @@ class Dark_Mode {
 			$user_id = get_current_user_id();
 		}
 
-		// Check if the user is using Dark Mode.
-		if ( 'on' === get_user_meta( $user_id, 'dark_mode', true ) ) {
-			/**
-			 * Filters when Dark Mode is on.
-			 *
-			 * @since 2.0
-			 *
-			 * @param boolean          Defaults to true.
-			 * @param int     $user_id The current user id.
-			 */
-			return apply_filters( 'is_using_dark_mode', true, $user_id );
-		}
+		$is_using_dark_mode = ( 'on' === get_user_meta( $user_id, 'dark_mode', true ) );
 
 		/**
-		 * Filters when Dark Mode is off.
+		 * Filters when Dark Mode is on.
 		 *
 		 * @since 2.0
 		 *
 		 * @param boolean          Defaults to true.
 		 * @param int     $user_id The current user id.
 		 */
-		return apply_filters( 'not_using_dark_mode', false, $user_id );
+		return = apply_filters( 'is_using_dark_mode', $is_using_dark_mode, $user_id );
 	}
 
 	/**


### PR DESCRIPTION
This PR will remove the `not_using_dark_mode` filter as it is redundant to have that. `is_using_dark_mode` will have that status as the first parameter.
Fixes #145 

It also adds the use of static cache in the method to prevent filters from running again. If plugin/theme authors want to use this filter they should do so at an early enough stage.