### PR TITLE
Update nag ID missing

### DIFF
--- a/dark-mode.scss
+++ b/dark-mode.scss
@@ -239,7 +239,8 @@ body:not(.gutenberg-editor-page) {
 		.notice,
 		.error,
 		.updated,
-		.update-nag {
+		.update-nag,
+		#update-nag {
 
 			background-color: $ultra-grey;
 


### PR DESCRIPTION
The update notice can also be set as an ID according to WP styles. The Genesis Framework is using this for example.
This PR adds the ID in the dark mode styles.